### PR TITLE
Lint files only in a source code folder

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const stylelint = require('neutrino-middleware-stylelint');
 module.exports = (neutrino) => {
   neutrino.use(stylelint, {
     config: {
+      context: neutrino.options.source,
       extends: require.resolve('stylelint-config-standard')
     }
   });


### PR DESCRIPTION
Limit the scope of style linting. Otherwise 'build', 'test' and probably 'node_modules' folders will be also checked